### PR TITLE
chore: add lefthook pre-commit checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # PNRGO
 Toy implementation of PRNG written in Go.
+
+## Development
+
+Install development tools with aqua:
+
+```bash
+aqua i
+```
+
+Install lefthook:
+
+```bash
+lefthook install
+```
+
+lefthook runs `golangci-lint run` and `go test ./... --shuffle on --parallel 10 --p 10` before commit.

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,3 +12,4 @@ registries:
   ref: v4.493.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: golangci/golangci-lint@v2.11.4
+- name: evilmartians/lefthook@v2.1.6

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.go"
+      run: golangci-lint run
+    test:
+      glob: "*.go"
+      run: go test ./... --shuffle on --parallel 10 --p 10


### PR DESCRIPTION
## Summary
- add lefthook managed by aqua
- run golangci-lint and go test before commit
- document aqua and lefthook setup in README

## Verification
- aqua exec -- lefthook validate
- aqua exec -- golangci-lint run
- go test ./... --shuffle on --parallel 10 --p 10
- aqua exec -- lefthook run pre-commit --all-files