### PR TITLE
Add actions security workflow

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.56.6
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,19 +3,26 @@ name: Go test&lint
 on:
   push:
 
+
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       - name: Run test
         run: |
           go test ./... --shuffle on --parallel 10 --p 10
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.57.2

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,15 +1,10 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# checksum:
-#   enabled: true
-#   require_checksum: true
-#   supported_envs:
-#   - all
 registries:
-- type: standard
-  ref: v4.510.0 # renovate: depName=aquaproj/aqua-registry
+  - type: standard
+    ref: v4.510.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: golangci/golangci-lint@v2.11.4
-- name: evilmartians/lefthook@v2.1.6
+  - name: golangci/golangci-lint@v2.11.4
+  - name: evilmartians/lefthook@v2.1.6
+  - name: suzuki-shunsuke/pinact@v4.0.0
+  - name: zizmorcore/zizmor@v1.25.2


### PR DESCRIPTION
## Summary
- Add an actions-security workflow that runs pinact and zizmor
- Manage pinact and zizmor with aqua
- Pin GitHub Actions references by SHA and apply zizmor workflow hardening

## Verification
- `git diff --check -- .github/workflows aqua.yaml`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format plain .`